### PR TITLE
Fix IndexError in LeetLetters transformation

### DIFF
--- a/nlaugmenter/transformations/leet_letters/transformation.py
+++ b/nlaugmenter/transformations/leet_letters/transformation.py
@@ -81,10 +81,6 @@ class LeetLetters(SentenceOperation):
                 leet_candidates, k=max_leet_replacements
             )
 
-            leet_replacements = random.choices(
-                leet_candidates, k=max_leet_replacements
-            )
-
             # Conduct replacement
             sentence_list = list(sentence)
             for idx, leet in leet_replacements:

--- a/nlaugmenter/transformations/leet_letters/transformation.py
+++ b/nlaugmenter/transformations/leet_letters/transformation.py
@@ -70,6 +70,17 @@ class LeetLetters(SentenceOperation):
             for idx, letter in enumerate(sentence):
                 if letter in leet_letter_mappings:
                     leet_candidates.append((idx, leet_letter_mappings[letter]))
+
+            if not leet_candidates:
+                perturbed_texts.append(sentence)
+                continue
+
+            max_leet_replacements = min(max_leet_replacements, len(leet_candidates))
+
+            leet_replacements = random.choices(
+                leet_candidates, k=max_leet_replacements
+            )
+
             leet_replacements = random.choices(
                 leet_candidates, k=max_leet_replacements
             )


### PR DESCRIPTION
# Issue
The LeetLetters transformation was raising an IndexError: list index out of range when processing text that doesn't contain any characters found in the leet letter mappings dictionary. This occurred because random.choices() was being called with an empty list when no leet candidates were found.
# Fix
Added defensive checks to:

1. Skip leet transformation and return the original text when no candidates for replacement are found
2. Cap the number of replacements to the number of available candidates

This ensures the transformation is robust when handling edge cases like:

- Empty strings
- Text with no characters that can be converted to leet speak
- Non-Latin alphabet text

# Testing
Verified the fix by running the guardrail benchmark with problematic inputs that previously caused the error.